### PR TITLE
Generate Doxygen documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ project(gnss_interface VERSION 0.1.0
 
 set(PROJECT_NAME_LARGE "GNSS Interface")
 
-set(${PROJECT_NAME}_DESCRIPTION_SUMMARY "C++ library for interfacing with Quectel GNSS L86 modules")
+set(${PROJECT_NAME}_DESCRIPTION_SUMMARY "C++ library for interfacing with NMEA 1082 GNSS modules")
 
 message(STATUS "Configuring ${PROJECT_NAME_LARGE}")
 message(STATUS "Version: ${PROJECT_VERSION}")
@@ -73,6 +73,14 @@ option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 # Compile library
 ###############################################################################
 add_subdirectory(src/cpp)
+
+###############################################################################
+# Build documentation
+###############################################################################
+option(BUILD_DOCUMENTATION "Build ${PROJECT_NAME} documentation" OFF)
+if(BUILD_DOCUMENTATION)
+    add_subdirectory(docs)
+endif()
 
 ###############################################################################
 # Build examples

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GNSS Interface
+# GNSS Interface {#index}
 
 **gnss_interface** is a `C++` library to get **GNSS** information from GNSS modules which communicate with **NMEA 0183** over UART.
 It has been originally developed targeting Quectel GNSS L86 modules, however, it can retrieve GNSS data from any GNSS device sending **NMEA 0183** sentences over UART.
@@ -7,6 +7,7 @@ It has been originally developed targeting Quectel GNSS L86 modules, however, it
 * [Getting started](#getting-started)
     * [Prerequisites](#prerequisites)
     * [Build and install](#build-and-install)
+    * [Build documentation](#build-documentation)
     * [Run examples](#run-examples)
 * [Usage](#usage)
 * [Authors](#authors)
@@ -56,6 +57,16 @@ To install the library system-wide, just omit the `CMAKE_INSTALL_PREFIX`:
 ```bash
 cd ~/gnss_interface/build
 cmake ..
+cmake --build . --target install
+```
+
+### Build documentation
+
+It is possible to generate the library's documentation passing CMake option `-DBUILD_DOCUMENTATION=0N` (defaults to `OFF`) on the configuration step:
+
+```bash
+cd ~/gnss_interface/build
+cmake .. -DCMAKE_INSTALL_PREFIX=<user-specified-dir> -DBUILD_DOCUMENTATION=ON
 cmake --build . --target install
 ```
 
@@ -150,6 +161,6 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 ## To-Do
 
-- Add robustness to `SerialInterface`
+- Add robustness to `SerialInterface`.
 - Process other **NMEA 0183** sentences. See [gnss_l86_output.txt](gnss_l86_output.txt) for an example of the messages coming from the module.
 - Send commands to GNSS modules using [**PMTK**](https://www.quectel.com/UploadImage/Downlad/Quectel_GNSS_SDK_Commands_Manual_V1.2.pdf) protocol.

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,88 @@
+# Copyright (c) 2021 Eduardo Ponz Segrelles.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# Build Doxygen documentation
+####################################################################################################
+
+file(GLOB_RECURSE HPP_FILES "${PROJECT_SOURCE_DIR}/include/**/*.h*")
+set(INDEX_FILE ${PROJECT_SOURCE_DIR}/README.md)
+set(LICENSE_FILE ${PROJECT_SOURCE_DIR}/LICENSE.md)
+set(PROJECT_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
+set(PROJECT_SOURCE_DOCS_DIR ${PROJECT_SOURCE_DIR}/docs)
+set(PROJECT_BINARY_DOCS_DIR ${PROJECT_BINARY_DIR}/docs)
+set(DOCS_OUTPUT_HTML_DIR ${PROJECT_BINARY_DOCS_DIR}/html)
+
+find_package(Doxygen REQUIRED)
+# Doxygen related variables
+set(DOXYGEN_INPUT_DIR "${PROJECT_INCLUDE_DIR}")
+set(DOXYGEN_OUTPUT_DIR "${PROJECT_BINARY_DOCS_DIR}/doxygen")
+set(DOXYGEN_OUTPUT_XML_DIR "${DOXYGEN_OUTPUT_DIR}/xml")
+set(DOXYGEN_OUTPUT_HTML_DIR "${DOXYGEN_OUTPUT_DIR}/html")
+set(DOXYGEN_INDEX_FILE "${DOXYGEN_OUTPUT_XML_DIR}/index.xml")
+set(DOXYFILE_IN "${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in")
+set(DOXYFILE_OUT ${PROJECT_BINARY_DOCS_DIR}/Doxyfile)
+
+# Create doxygen directories
+add_custom_target(doc-dirs
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DOCS_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${DOCS_OUTPUT_HTML_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${DOXYGEN_OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${DOXYGEN_OUTPUT_XML_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${DOXYGEN_OUTPUT_HTML_DIR}
+    COMMENT "Creating documentation directories" VERBATIM)
+
+# Configure doxygen
+configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
+
+# Doxygen command
+add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
+    DEPENDS ${HPP_FILES}
+    MAIN_DEPENDENCY ${DOXYFILE_OUT} ${DOXYFILE_IN}
+    COMMENT "Generating doxygen documentation")
+
+# Generate API reference
+add_custom_target(doxygen ALL
+    DEPENDS ${DOXYGEN_INDEX_FILE}
+    COMMENT "Generated API documentation with doxygen" VERBATIM)
+add_dependencies(doxygen doc-dirs)
+
+# Install doxygen generated XML files
+install(DIRECTORY ${DOXYGEN_OUTPUT_XML_DIR}
+    DESTINATION docs/${PROJECT_NAME}/doxygen
+    COMPONENT gnss_interface-doxygen)
+
+install(DIRECTORY ${DOXYGEN_OUTPUT_HTML_DIR}
+    DESTINATION docs/${PROJECT_NAME}/doxygen
+    COMPONENT gnss_interface-doxygen)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,0 +1,373 @@
+# Doxyfile 1.8.15
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = "@PROJECT_NAME_LARGE@"
+PROJECT_NUMBER         = "TODO"
+PROJECT_BRIEF          =
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       = "@DOXYGEN_OUTPUT_DIR@"
+CREATE_SUBDIRS         = NO
+ALLOW_UNICODE_NAMES    = NO
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+ALWAYS_DETAILED_SEC    = NO
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = YES
+STRIP_FROM_PATH        = "@DOXYGEN_INPUT_DIR@/.."
+STRIP_FROM_INC_PATH    = "@DOXYGEN_INPUT_DIR@/.."
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+QT_AUTOBRIEF           = YES
+MULTILINE_CPP_IS_BRIEF = NO
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+ALIASES                =
+TCL_SUBST              =
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+EXTENSION_MAPPING      =
+MARKDOWN_SUPPORT       = YES
+TOC_INCLUDE_HEADINGS   = 0
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = NO
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+GROUP_NESTED_COMPOUNDS = NO
+SUBGROUPING            = YES
+INLINE_GROUPED_CLASSES = NO
+INLINE_SIMPLE_STRUCTS  = NO
+TYPEDEF_HIDES_STRUCT   = NO
+LOOKUP_CACHE_SIZE      = 0
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_PACKAGE        = NO
+EXTRACT_STATIC         = NO
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = NO
+EXTRACT_ANON_NSPACES   = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = YES
+HIDE_SCOPE_NAMES       = NO
+HIDE_COMPOUND_REFERENCE= NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_GROUPED_MEMB_INC  = NO
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+CITE_BIB_FILES         =
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = "@INDEX_FILE@" \
+                         "@LICENSE_FILE@" \
+                         "@DOXYGEN_INPUT_DIR@"
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.c \
+                         *.cc \
+                         *.cxx \
+                         *.cpp \
+                         *.c++ \
+                         *.java \
+                         *.ii \
+                         *.ixx \
+                         *.ipp \
+                         *.i++ \
+                         *.inl \
+                         *.idl \
+                         *.ddl \
+                         *.odl \
+                         *.h \
+                         *.hh \
+                         *.hxx \
+                         *.hpp \
+                         *.h++ \
+                         *.cs \
+                         *.d \
+                         *.php \
+                         *.php4 \
+                         *.php5 \
+                         *.phtml \
+                         *.inc \
+                         *.m \
+                         *.markdown \
+                         *.md \
+                         *.mm \
+                         *.dox \
+                         *.py \
+                         *.pyw \
+                         *.f90 \
+                         *.f95 \
+                         *.f03 \
+                         *.f08 \
+                         *.f \
+                         *.for \
+                         *.tcl \
+                         *.vhd \
+                         *.vhdl \
+                         *.ucf \
+                         *.qsf \
+                         *.ice
+RECURSIVE              = YES
+EXCLUDE                =
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           = "@PROJECT_SOURCE_DIR@"
+EXAMPLE_PATTERNS       = *
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+USE_MDFILE_AS_MAINPAGE =
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+SOURCE_TOOLTIPS        = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+COLS_IN_ALPHA_INDEX    = 5
+IGNORE_PREFIX          =
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = "@DOXYGEN_OUTPUT_DIR@/html"
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_FILES       =
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_TIMESTAMP         = NO
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_INDEX_NUM_ENTRIES = 100
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = NO
+ENUM_VALUES_PER_LINE   = 4
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 10
+FORMULA_TRANSPARENT    = YES
+USE_MATHJAX            = NO
+MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/
+MATHJAX_EXTENSIONS     =
+MATHJAX_CODEFILE       =
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+EXTERNAL_SEARCH        = NO
+SEARCHENGINE_URL       =
+SEARCHDATA_FILE        = searchdata.xml
+EXTERNAL_SEARCH_ID     =
+EXTRA_SEARCH_MAPPINGS  =
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         =
+MAKEINDEX_CMD_NAME     = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
+LATEX_FOOTER           =
+LATEX_EXTRA_STYLESHEET =
+LATEX_EXTRA_FILES      =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+LATEX_SOURCE_CODE      = NO
+LATEX_BIB_STYLE        = plain
+LATEX_TIMESTAMP        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+RTF_OUTPUT             = rtf
+COMPACT_RTF            = NO
+RTF_HYPERLINKS         = NO
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
+RTF_SOURCE_CODE        = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+MAN_OUTPUT             = man
+MAN_EXTENSION          = .3
+MAN_SUBDIR             =
+MAN_LINKS              = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = YES
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the DOCBOOK output
+#---------------------------------------------------------------------------
+GENERATE_DOCBOOK       = NO
+DOCBOOK_OUTPUT         = docbook
+DOCBOOK_PROGRAMLISTING = NO
+#---------------------------------------------------------------------------
+# Configuration options for the AutoGen Definitions output
+#---------------------------------------------------------------------------
+GENERATE_AUTOGEN_DEF   = NO
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+PERLMOD_LATEX          = NO
+PERLMOD_PRETTY         = YES
+PERLMOD_MAKEVAR_PREFIX =
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             = "DOXYGEN_DOCUMENTATION=1"
+EXPAND_AS_DEFINED      = YES
+SKIP_FUNCTION_MACROS   = YES
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+EXTERNAL_PAGES         = YES
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+CLASS_DIAGRAMS         = YES
+DIA_PATH               =
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = NO
+DOT_NUM_THREADS        = 0
+DOT_FONTNAME           = Helvetica
+DOT_FONTSIZE           = 10
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+UML_LIMIT_NUM_FIELDS   = 10
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+INTERACTIVE_SVG        = NO
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DIAFILE_DIRS           =
+PLANTUML_JAR_PATH      =
+PLANTUML_CFG_FILE      =
+PLANTUML_INCLUDE_PATH  =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_TRANSPARENT        = NO
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES

--- a/include/gnss_interface/GnssInterface.hpp
+++ b/include/gnss_interface/GnssInterface.hpp
@@ -37,8 +37,10 @@ class GnssInterfaceImpl;
 /**
  * @class GnssInterface
  *
- * This class provides an interface with GNSS modules using NMEA 0183 protocol over serial
- * connections. It can be used to:
+ * @brief This class provides an interface with GNSS modules using NMEA 0183 protocol over serial
+ * connections.
+ *
+ * It can be used to:
  *     * Open and close serial connection with the modules.
  *     * Wait for specific NMEA sentences to be received.
  *     * Read incoming GNSS data in a parsed and understanble manner.
@@ -66,7 +68,7 @@ public:
      * @param[in] baudrate The communication baudrate.
      * @return \c open() can return:
      *     * ReturnCode::RETURN_CODE_OK if the port is opened correctly.
-     *     * ReturnCode::RETURN_ILLEGAL_OPERATION if a previous call to open was performed in the
+     *     * ReturnCode::RETURN_CODE_ILLEGAL_OPERATION if a previous call to open was performed in the
      *       same GnssInterface instance, regardless of the port.
      */
     ReturnCode open(
@@ -87,7 +89,7 @@ public:
      *
      * @return \c close() can return:
      *     * ReturnCode::RETURN_CODE_OK if the connection was successfully closed.
-     *     * ReturnCode::RETURN_ILLEGAL_OPERATION if there was not open connection.
+     *     * ReturnCode::RETURN_CODE_ILLEGAL_OPERATION if there was not open connection.
      */
     ReturnCode close();
 
@@ -121,7 +123,7 @@ public:
      *       been received.
      *     * ReturnCode::RETURN_CODE_NO_DATA if some other thread called \c close() on the
      *       \c GnssInterface instance, which unblocks any \c wait_for_data() calls.
-     *     * ReturnCode::RETURN_ILLEGAL_OPERATION if there was not open connection.
+     *     * ReturnCode::RETURN_CODE_ILLEGAL_OPERATION if there was not open connection.
      */
     ReturnCode wait_for_data(
             NMEA0183DataKindMask data_mask = NMEA0183DataKindMask::all());

--- a/include/gnss_interface/data.hpp
+++ b/include/gnss_interface/data.hpp
@@ -38,7 +38,7 @@ namespace gnss_interface
 /**
  * \struct NMEA0183Data
  *
- * Base struct for all NMEA 0183 Data types
+ * @brief Base struct for all NMEA 0183 Data types
  */
 struct NMEA0183Data
 {
@@ -62,6 +62,11 @@ struct NMEA0183Data
     NMEA0183DataKind kind;
 };
 
+/**
+ * \struct GPGGAData
+ *
+ * @brief Struct for data from GPGGA sentences
+ */
 struct GPGGAData : NMEA0183Data
 {
     //! UTC time hhmmss.milliseconds

--- a/include/gnss_interface/types.hpp
+++ b/include/gnss_interface/types.hpp
@@ -33,7 +33,7 @@ namespace gnss_interface {
 /**
  * @enum NMEA0183DataKind
  *
- * Holds all the supported NMEA 0183 sentences.
+ * @brief Holds all the supported NMEA 0183 sentences.
  */
 enum class NMEA0183DataKind : int32_t
 {
@@ -60,7 +60,9 @@ using NMEA0183DataKindMask = Bitmask<NMEA0183DataKind>;
 /**
  * @class ReturnCode
  *
- * Provides understandable return codes for the different operations that the library performs.
+ * @brief Provides understandable return codes for the different operations that the library
+ *        performs.
+ *
  * These return codes can be easily compared for applications to handle different scenarios.
  */
 class ReturnCode

--- a/src/cpp/GnssInterfaceImpl.hpp
+++ b/src/cpp/GnssInterfaceImpl.hpp
@@ -74,7 +74,7 @@ public:
      * @param[in] baudrate The communication baudrate.
      * @return \c open() can return:
      *     * ReturnCode::RETURN_CODE_OK if the port is opened correctly.
-     *     * ReturnCode::RETURN_ILLEGAL_OPERATION if a previous call to open was performed in the
+     *     * ReturnCode::RETURN_CODE_ILLEGAL_OPERATION if a previous call to open was performed in the
      *       same GnssInterface instance, regardless of the port.
      */
     ReturnCode open(
@@ -95,7 +95,7 @@ public:
      *
      * @return \c close() can return:
      *     * ReturnCode::RETURN_CODE_OK if the connection was successfully closed.
-     *     * ReturnCode::RETURN_ILLEGAL_OPERATION if there was not open connection.
+     *     * ReturnCode::RETURN_CODE_ILLEGAL_OPERATION if there was not open connection.
      */
     ReturnCode close();
 
@@ -110,7 +110,7 @@ public:
      * @return \c take_next() can return:
      *     * ReturnCode::RETURN_CODE_OK if the operation succeeded.
      *     * ReturnCode::RETURN_CODE_NO_DATA if there are not any un-taken \c GPGGAData samples.
-     *     * ReturnCode::RETURN_ILLEGAL_OPERATION if there was not open connection.
+     *     * ReturnCode::RETURN_CODE_ILLEGAL_OPERATION if there was not open connection.
      */
     ReturnCode take_next(
             GPGGAData& gpgga);

--- a/src/cpp/SerialInterface.hpp
+++ b/src/cpp/SerialInterface.hpp
@@ -98,7 +98,7 @@ public:
     /**
      * Blocks until a line is received from the serial device.
      *
-     * Eventual '\n' or '\r\n' characters at the end of the string are removed.
+     * Eventual \c '\n' or \c '\r\n' characters at the end of the string are removed.
      *
      * \param[out] result A string to store the read line.
      * \return true if success; false otherwise.


### PR DESCRIPTION
This PR adds a `-DBUILD_DOCUMENTATION` CMake option to generate Doxygen HTML and XML documentation

Signed-off-by: Eduardo Ponz Segrelles <eduardoponz@eprosima.com>