### PR TITLE
Notify all waiting threads

### DIFF
--- a/src/cpp/GnssInterfaceImpl.cpp
+++ b/src/cpp/GnssInterfaceImpl.cpp
@@ -124,7 +124,7 @@ ReturnCode GnssInterfaceImpl::close()
         serial_interface_ = nullptr;
         // Break any wait_for_data
         lck.unlock();
-        cv_.notify_one();
+        cv_.notify_all();
         return ReturnCode::RETURN_CODE_OK;
     }
     return ReturnCode::RETURN_CODE_ILLEGAL_OPERATION;
@@ -241,7 +241,7 @@ bool GnssInterfaceImpl::parse_raw_line_(
         if (process_gpgga_(line))
         {
             new_position_.store(true);
-            cv_.notify_one();
+            cv_.notify_all();
         }
     }
     return false;


### PR DESCRIPTION
With this PR, all threads on `wait_for_data()` get notified whenever data arrives or the GNSS interface closes down.

Signed-off-by: Eduardo Ponz Segrelles <eduardoponz@eprosima.com>