### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,51 @@
+---
+name: Pull request
+about: Make sure the contributing process is followed
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## References
+<!-- List related issues -->
+
+## PR description
+<!-- Describe what this PR brings -->
+
+## Pre-Review Checklist for the PR Author
+
+* [ ] Branch follows the naming conventions specified in [CONTRIBUTING.md](../../CONTRIBUTING.md)
+* [ ] Design documentation is provided
+* [ ] Testing plan is documented
+* [ ] Tests are implemented
+* [ ] Implementation is complete in accordance with the design documents
+* [ ] Documentation has been updated (if needed)
+* [ ] All new files contain license note
+* [ ] Commit messages refer to the tackled issue (e.g `Refs #12: This is a commit message`)
+* [ ] Tests pass locally
+* [ ] All checks have passed
+* [ ] Assign issue to reviewer
+
+## Notes for Reviewer
+<!-- Items in addition to the checklist below that the reviewer should look for -->
+
+## Checklist for the PR Reviewer
+
+* [ ] Commits are properly organized and messages are comprehensible and relevant
+* [ ] Tests are in accordance with design documentation
+* [ ] Implementation is in accordance with design documentation
+* [ ] Documentation fully describes the feature
+* [ ] Check API breaks
+* [ ] Check ABI breaks
+* [ ] Public API changes are properly documented
+
+## Post-review Checklist for the PR Author
+
+1. [ ] All open points are addressed and tracked via issues
+
+## Post-review Checklist for maintainer
+
+1. [ ] All checkboxes in the PR checklist are checked or crossed out
+1. [ ] Assign PR to milestone and mark as ready
+1. [ ] Squash and merge


### PR DESCRIPTION
This PR addresses #12. It provides a pull request template so that both contributors and reviewers can go through a checklist before merging any change.

Signed-off-by: Eduardo Ponz Segrelles <eduardoponz@eprosima.com>